### PR TITLE
Fix mobile logo width overflow

### DIFF
--- a/styles/index.css
+++ b/styles/index.css
@@ -429,6 +429,10 @@ main > div > span > span.morse p {
   main > div {
     margin: 0;
   }
+  main > div > span > span:not(.morse) {
+    width: 80vw;
+    max-width: 12rem;
+  }
   #settings {
     --closed-left: -20rem;
     transform: translate(var(--closed-left), 14rem);


### PR DESCRIPTION
## Summary
- adjust logo span width on small screens to keep logo within viewport

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68451caa5d3c8325a2b90fb5cad40a6f